### PR TITLE
Prune remote deleted branches

### DIFF
--- a/repo-update.sh
+++ b/repo-update.sh
@@ -24,6 +24,7 @@ function update {
   echo $editedFiles
   git checkout master
   git pull --rebase
+  git remote update --prune
   git checkout -
   if [[ $editedFiles != *"No local changes to save"* ]]
   then


### PR DESCRIPTION
Hello @KillianKemps :)

I'm using your script daily and enjoying it so far.  
But the repos keep the whole branch history, since only a `git pull` hence `git fetch` is done.

By adding that other command we ensure an up to date remote branches state.

Although it's preforming another fetch...
